### PR TITLE
generate: argument to enable parallel generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7]
+
+### Added
+
+- `generate`: option `--parallel-generation-threads` to specify the number of threads to use for parallel generation.
+  The default is 0, which means no parallel generation.
+
 ## [1.6]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ allprojects {
 }
 
 val versionMajor = 1
-val versionMinor = 6
+val versionMinor = 7
 
 val suffix = run {
     val buildNumberStr = System.getenv("BUILD_NUMBER")

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -14,6 +14,7 @@ usage: execute-generators [-h] [--plugin PLUGIN]... [--macro MACRO]...
                           [--plugin-location PLUGIN_LOCATION]
                           [--build-number BUILD_NUMBER] --project PROJECT
                           [--test-mode] [--environment ENVIRONMENT]
+                          [--parallel-generation-threads THREADS]
                           [--log-level LOG_LEVEL] [--model MODEL]...
                           [--module MODULE]...
                           [--exclude-model EXCLUDE_MODEL]...
@@ -24,37 +25,41 @@ required arguments:
 
 
 optional arguments:
-  -h, --help                          show this help message and exit
+  -h, --help                              show this help message and exit
+        
+  --plugin PLUGIN                         plugin to to load. The format is
+                                          --plugin=<id>::<path>
+        
+  --macro MACRO                           macro to define. The format is
+                                          --macro=<name>::<value>
+        
+  --plugin-location PLUGIN_LOCATION       location to load additional plugins from
+        
+  --build-number BUILD_NUMBER             build number used to determine if the
+                                          plugins are compatible
+        
+  --test-mode                             run in test mode
+        
+  --environment ENVIRONMENT               kind of environment to initialize,
+                                          supported values are 'idea' (default),
+                                          'mps'
+                                      
+  --parallel-generation-threads THREADS   number of threads to use for parallel
+                                          generation. Default: 0 (parallel
+                                          generation disabled).                                      
 
-  --plugin PLUGIN                     plugin to to load. The format is
-                                      --plugin=<id>::<path>
-
-  --macro MACRO                       macro to define. The format is
-                                      --macro=<name>::<value>
-
-  --plugin-location PLUGIN_LOCATION   location to load additional plugins from
-
-  --build-number BUILD_NUMBER         build number used to determine if the
-                                      plugins are compatible
-
-  --test-mode                         run in test mode
-
-  --environment ENVIRONMENT           kind of environment to initialize,
-                                      supported values are 'idea' (default),
-                                      'mps'
-
-  --log-level LOG_LEVEL               console log level. Supported values:
-                                      info, warn, error, off. Default: warn.
-
-  --model MODEL                       list of models to generate
-
-  --module MODULE                     list of modules to generate
-
-  --exclude-model EXCLUDE_MODEL       list of models to exclude from
-                                      generation
-
-  --exclude-module EXCLUDE_MODULE     list of modules to exclude from
-                                      generation
+  --log-level LOG_LEVEL                   console log level. Supported values:
+                                          info, warn, error, off. Default: warn.
+        
+  --model MODEL                           list of models to generate
+        
+  --module MODULE                         list of modules to generate
+        
+  --exclude-model EXCLUDE_MODEL           list of models to exclude from
+                                          generation
+        
+  --exclude-module EXCLUDE_MODULE         list of modules to exclude from
+                                          generation
 ```
 
 ## Gradle example (Kotlin syntax)

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -21,7 +21,7 @@ usage: execute-generators [-h] [--plugin PLUGIN]... [--macro MACRO]...
                           [--exclude-module EXCLUDE_MODULE]...
 
 required arguments:
-  --project PROJECT                   project to generate from
+  --project PROJECT                       project to generate from
 
 
 optional arguments:

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -82,7 +82,7 @@ val unpackMps by tasks.registering(Sync::class) {
 }
 
 val generate by tasks.registering(JavaExec::class) {
-    dependsOn(unpackTask)
+    dependsOn(unpackMps)
     classpath(executeGenerators)
     classpath(fileTree(mpsHome) {
         include("lib/**/*.jar")

--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     compileOnly(zipTree({ mpsZip.singleFile }).matching {
         include("lib/mps-openapi.jar")
         include("lib/mps-core.jar")
+        include("lib/mps-generator.jar")
         include("lib/mps-messaging.jar")
         include("lib/platform-api.jar")
         include("lib/util.jar")

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/GenerateArgs.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/GenerateArgs.kt
@@ -1,6 +1,8 @@
 package de.itemis.mps.gradle.generate
 
 import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.InvalidArgumentException
+import com.xenomachina.argparser.default
 import de.itemis.mps.gradle.project.loader.Args
 
 class GenerateArgs(parser: ArgParser) : Args(parser) {
@@ -8,4 +10,10 @@ class GenerateArgs(parser: ArgParser) : Args(parser) {
     val modules by parser.adding("--module", help = "list of modules to generate")
     val excludeModels by parser.adding("--exclude-model", help = "list of models to exclude from generation")
     val excludeModules by parser.adding("--exclude-module", help = "list of modules to exclude from generation")
+    val parallelGenerationThreads by parser.storing(
+        "--parallel-generation-threads",
+        help = "Number of threads to use for parallel generation. Value of 0 means that parallel generation is disabled. Default: 0"
+    ) { toInt() }
+        .default(0)
+        .addValidator { if (value < 0) throw InvalidArgumentException("parallel-generation-threads must be >= 0") }
 }

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Helper.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Helper.kt
@@ -4,6 +4,7 @@ package de.itemis.mps.gradle.generate
 import com.intellij.openapi.util.IconLoader
 import de.itemis.mps.gradle.project.loader.EnvironmentKind
 import de.itemis.mps.gradle.project.loader.ModuleAndModelMatcher
+import jetbrains.mps.generator.GenerationSettingsProvider
 import jetbrains.mps.make.MakeSession
 import jetbrains.mps.make.facet.FacetRegistry
 import jetbrains.mps.make.facet.IFacet
@@ -121,6 +122,10 @@ private fun makeModels(proj: Project, models: List<SModel>): Boolean {
     val session = MakeSession(proj, MsgHandler(), true)
     val res = ModelsToResources(models).resources().toList()
     val makeService = BuildMakeService()
+
+    val generationSettings = proj.getComponent(GenerationSettingsProvider::class.java).generationSettings
+    generationSettings.isParallelGenerator = true
+    generationSettings.numberOfParallelThreads = 2
 
     if (res.isEmpty()) {
         logger.warn("nothing to generate")

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -23,6 +23,9 @@ val SUPPORTED_MPS_VERSIONS = arrayOf("2021.1.4", "2021.2.5", "2021.3.2")
 val GENERATION_TESTS = listOf(
     GenerationTest("generateBuildSolution", "generate-build-solution", listOf("--model", "my.build.script"),
         expectation = GenerationTestExpectation.SuccessWithFiles("solutions/my.build/build.xml")),
+    GenerationTest("generateBuildSolutionParallel", "generate-build-solution",
+        listOf("--model", "my.build.script", "--parallel-generation-threads=4"),
+        expectation = GenerationTestExpectation.SuccessWithFiles("solutions/my.build/build.xml")),
     GenerationTest("generateSimple", "generate-simple", listOf()),
     GenerationTest("generateBuildSolutionWithMpsEnvironment",
         "generate-build-solution", listOf("--model", "my.build.script", "--environment", "MPS")),


### PR DESCRIPTION
Added an argument `--parallel-generation-threads` to `execute-generators` task with the default value 0.
The value of 0 means that parallel generation is disabled (same as previous behaviour)
Positive values mean that parallel generation is enabled with the provided number of threads.