### PR TITLE
generate: distinguishable exit code when nothing to generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9]
+
+### Added
+
+- `generate`: when there is nothing to generate the exit code is `254` now, to distinguish it from the general 
+  generation error (exit code `255`). This is still treated as an error like in the previous versions, which matches 
+  MPS behaviour.
+
+### Changed 
+
+- `generate`: exit code for a general MPS error is now `255` on all systems. Previously `-1` was returned, which could
+  be interpreted as `255` or `-1` depending on the system.
+
 ## [1.8]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ allprojects {
 }
 
 val versionMajor = 1
-val versionMinor = 8
+val versionMinor = 9
 
 val suffix = run {
     val buildCounterStr = System.getenv("BUILD_COUNTER")

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -60,6 +60,10 @@ optional arguments:
         
   --exclude-module EXCLUDE_MODULE         list of modules to exclude from
                                           generation
+
+error exit codes:
+  254: nothing to generate
+  255: general MPS error
 ```
 
 ## Gradle example (Kotlin syntax)

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Main.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Main.kt
@@ -9,7 +9,7 @@ import org.apache.log4j.Logger
 
 fun main(args: Array<String>) = mainBody("execute-generators") {
     val parsed = ArgParser(args).parseInto(::GenerateArgs)
-    var result = false
+    var result = GenerationResult.Error
 
     val logger = Logger.getLogger("de.itemis.mps.gradle.generate")
     configureLogging(parsed.logLevel)
@@ -21,9 +21,9 @@ fun main(args: Array<String>) = mainBody("execute-generators") {
     } catch (t: Throwable) {
         logger.fatal("error generating", t)
     }
-    if(!result) {
-        throw SystemExitException("generation failed", -1)
+    if(result.isFailure()) {
+        throw SystemExitException("generation failed", result.exitCode)
     }
 
-    System.exit(0)
+    System.exit(result.exitCode)
 }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -29,6 +29,8 @@ val GENERATION_TESTS = listOf(
     GenerationTest("generateSimple", "generate-simple", listOf()),
     GenerationTest("generateBuildSolutionWithMpsEnvironment",
         "generate-build-solution", listOf("--model", "my.build.script", "--environment", "MPS")),
+    GenerationTest("generateEmpty", "generate-simple", listOf("--exclude-model", "my.solution.java"),
+        expectation = GenerationTestExpectation.Empty),
 
     GenerationTest(
         name = "generateIncorrect",
@@ -106,7 +108,12 @@ interface GenerationTestExpectation {
 
     object Failure : GenerationTestExpectation {
         override fun verify(testCase: GenerationTest, exitCode: Int): String? =
-            if (exitCode != 0) null else "generation succeeded unexpectedly"
+            if (exitCode == 255) null else "generation did not fail unexpectedly (exit value $exitCode)"
+    }
+
+    object Empty : GenerationTestExpectation {
+        override fun verify(testCase: GenerationTest, exitCode: Int): String? =
+            if (exitCode == 254) null else "generation was not empty unexpectedly (exit value $exitCode)"
     }
 
     data class SuccessWithFiles(val files: Set<File>) : GenerationTestExpectation {


### PR DESCRIPTION
Changes:

- Added a special exit code `254` when there is nothing to generate. This situation should be distinguishable from other generation errors, because it may be a normal situation and not an error upstream. However, it is still treated as an error, like in the previous version, and because MPS also treats this situation as an error.
- Changed the exit code of a generic generation error to always be `255`. Previously `-1` was used, which resulted in `-1` or `255` depending on the system.