### PR TITLE
project-loader: load project libraries, automatically find plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `project-loader` will now load project libraries from `.mps/libraries.xml` under the project directory when using MPS
   environment (can be disabled via `--no-libraries`).
+- `project-loader`: new `--plugin-root` argument. Loader automatically detects plugins in subdirectories of plugin roots.
 
 ## 1.14.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.15.0
+
+### Added
+
+- `project-loader` will now load project libraries from `.mps/libraries.xml` under the project directory when using MPS
+  environment (can be disabled via `--no-libraries`).
+
 ## 1.14.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `project-loader` will now load project libraries from `.mps/libraries.xml` under the project directory when using MPS
-  environment (can be disabled via `--no-libraries`).
-- `project-loader`: new `--plugin-root` argument. Loader automatically detects plugins in subdirectories of plugin roots.
+- all backends (via `project-loader`): will now load project libraries from `.mps/libraries.xml` under the project 
+  directory when using MPS
+- all backends (via `project-loader`): new `--plugin-root` argument to automatically detect plugins in subdirectories 
+  of plugin roots.
 
 ## 1.14.3
 

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -11,11 +11,12 @@ is by using Gradle's `JavaExec` task. See below for an example.
 
 ```
 usage: execute-generators [-h] [--plugin PLUGIN]... [--macro MACRO]...
-                          [--plugin-location PLUGIN_LOCATION] [--build-number BUILD_NUMBER]
-                          [--test-mode] [--environment ENVIRONMENT] [--log-level LOG_LEVEL]
-                          [--no-libraries] --project PROJECT [--model MODEL]... [--module MODULE]...
-                          [--exclude-model EXCLUDE_MODEL]... [--exclude-module EXCLUDE_MODULE]...
-                          [--no-strict-mode] [--parallel-generation-threads THREADS]
+                          [--plugin-location PLUGIN_LOCATION] [--plugin-root PLUGIN_ROOT]...
+                          [--build-number BUILD_NUMBER] [--test-mode] [--environment ENVIRONMENT]
+                          [--log-level LOG_LEVEL] [--no-libraries] --project PROJECT
+                          [--model MODEL]... [--module MODULE]... [--exclude-model EXCLUDE_MODEL]...
+                          [--exclude-module EXCLUDE_MODULE]... [--no-strict-mode]
+                          [--parallel-generation-threads THREADS]
 
 required arguments:
   --project PROJECT                       project to generate from
@@ -29,6 +30,10 @@ optional arguments:
   --macro MACRO                           macro to define. The format is --macro=<name>::<value>
 
   --plugin-location PLUGIN_LOCATION       location to load additional plugins from
+
+  --plugin-root PLUGIN_ROOT               directory to search for plugins in. This detection
+                                          method is independent from --plugin and
+                                          --plugin-location
 
   --build-number BUILD_NUMBER             build number used to determine if the plugins are
                                           compatible

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -12,10 +12,10 @@ is by using Gradle's `JavaExec` task. See below for an example.
 ```
 usage: execute-generators [-h] [--plugin PLUGIN]... [--macro MACRO]...
                           [--plugin-location PLUGIN_LOCATION] [--build-number BUILD_NUMBER]
-                          --project PROJECT [--test-mode] [--environment ENVIRONMENT]
-                          [--log-level LOG_LEVEL] [--model MODEL]... [--module MODULE]...
+                          [--test-mode] [--environment ENVIRONMENT] [--log-level LOG_LEVEL]
+                          [--no-libraries] --project PROJECT [--model MODEL]... [--module MODULE]...
                           [--exclude-model EXCLUDE_MODEL]... [--exclude-module EXCLUDE_MODULE]...
-                          [--parallel-generation-threads THREADS] [--no-strict-mode]
+                          [--no-strict-mode] [--parallel-generation-threads THREADS]
 
 required arguments:
   --project PROJECT                       project to generate from
@@ -23,30 +23,32 @@ required arguments:
 
 optional arguments:
   -h, --help                              show this help message and exit
-        
-  --plugin PLUGIN                         plugin to to load. The format is --plugin=<id>::<path>
-        
+
+  --plugin PLUGIN                         plugin to load. The format is --plugin=<id>::<path>
+
   --macro MACRO                           macro to define. The format is --macro=<name>::<value>
-        
+
   --plugin-location PLUGIN_LOCATION       location to load additional plugins from
-        
+
   --build-number BUILD_NUMBER             build number used to determine if the plugins are
                                           compatible
-        
+
   --test-mode                             run in test mode
-        
+
   --environment ENVIRONMENT               kind of environment to initialize, supported values are
                                           'idea' (default), 'mps'
 
   --log-level LOG_LEVEL                   console log level. Supported values: info, warn, error,
                                           off. Default: warn.
-        
+
+  --no-libraries                          do not load project libraries under MPS environment
+
   --model MODEL                           list of models to generate
-        
+
   --module MODULE                         list of modules to generate
-        
+
   --exclude-model EXCLUDE_MODEL           list of models to exclude from generation
-        
+
   --exclude-module EXCLUDE_MODULE         list of modules to exclude from generation
 
   --no-strict-mode                        Disable strict generation mode. Strict mode places

--- a/execute/README.md
+++ b/execute/README.md
@@ -14,9 +14,9 @@ read and write locks itself, for example with `jetbrains.mps.lang.access`.
 
 ```
 usage: execute [-h] [--plugin PLUGIN]... [--macro MACRO]... [--plugin-location PLUGIN_LOCATION]
-               [--build-number BUILD_NUMBER] --project PROJECT [--test-mode]
-               [--environment ENVIRONMENT] [--log-level LOG_LEVEL] --module MODULE --class CLASS
-               --method METHOD [--arg ARG]...
+               [--build-number BUILD_NUMBER] [--test-mode] [--environment ENVIRONMENT]
+               [--log-level LOG_LEVEL] [--no-libraries] --project PROJECT --module MODULE
+               --class CLASS --method METHOD [--arg ARG]...
 
 required arguments:
   --project PROJECT                   project to generate from
@@ -33,7 +33,7 @@ required arguments:
 optional arguments:
   -h, --help                          show this help message and exit
 
-  --plugin PLUGIN                     plugin to to load. The format is --plugin=<id>::<path>
+  --plugin PLUGIN                     plugin to load. The format is --plugin=<id>::<path>
 
   --macro MACRO                       macro to define. The format is --macro=<name>::<value>
 
@@ -48,6 +48,8 @@ optional arguments:
 
   --log-level LOG_LEVEL               console log level. Supported values: info, warn, error, off.
                                       Default: warn.
+
+  --no-libraries                      do not load project libraries under MPS environment
 
   --arg ARG                           list of strings to pass to the method. Allowed only if the
                                       method signature is (Project, String[])

--- a/execute/README.md
+++ b/execute/README.md
@@ -14,9 +14,9 @@ read and write locks itself, for example with `jetbrains.mps.lang.access`.
 
 ```
 usage: execute [-h] [--plugin PLUGIN]... [--macro MACRO]... [--plugin-location PLUGIN_LOCATION]
-               [--build-number BUILD_NUMBER] [--test-mode] [--environment ENVIRONMENT]
-               [--log-level LOG_LEVEL] [--no-libraries] --project PROJECT --module MODULE
-               --class CLASS --method METHOD [--arg ARG]...
+               [--plugin-root PLUGIN_ROOT]... [--build-number BUILD_NUMBER] [--test-mode]
+               [--environment ENVIRONMENT] [--log-level LOG_LEVEL] [--no-libraries]
+               --project PROJECT --module MODULE --class CLASS --method METHOD [--arg ARG]...
 
 required arguments:
   --project PROJECT                   project to generate from
@@ -38,6 +38,9 @@ optional arguments:
   --macro MACRO                       macro to define. The format is --macro=<name>::<value>
 
   --plugin-location PLUGIN_LOCATION   location to load additional plugins from
+
+  --plugin-root PLUGIN_ROOT           directory to search for plugins in. This detection method is
+                                      independent from --plugin and --plugin-location
 
   --build-number BUILD_NUMBER         build number used to determine if the plugins are compatible
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version.backend=1.14.3
+version.backend=1.15.0
 version.project-loader=2.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version.backend=1.15.0
-version.project-loader=2.2.0
+version.project-loader=2.3.0

--- a/modelcheck/README.md
+++ b/modelcheck/README.md
@@ -16,11 +16,12 @@ The simplest way to run it is by using Gradle's `JavaExec` task. See below for a
 
 ```
 usage: modelcheck [-h] [--plugin PLUGIN]... [--macro MACRO]... [--plugin-location PLUGIN_LOCATION]
-                  [--build-number BUILD_NUMBER] [--test-mode] [--environment ENVIRONMENT]
-                  [--log-level LOG_LEVEL] [--no-libraries] --project PROJECT [--model MODEL]...
-                  [--module MODULE]... [--exclude-model EXCLUDE_MODEL]...
-                  [--exclude-module EXCLUDE_MODULE]... [--parallel] [--warning-as-error]
-                  [--error-no-fail] [--result-file RESULT_FILE] [--result-format RESULT_FORMAT]
+                  [--plugin-root PLUGIN_ROOT]... [--build-number BUILD_NUMBER] [--test-mode]
+                  [--environment ENVIRONMENT] [--log-level LOG_LEVEL] [--no-libraries]
+                  --project PROJECT [--model MODEL]... [--module MODULE]...
+                  [--exclude-model EXCLUDE_MODEL]... [--exclude-module EXCLUDE_MODULE]...
+                  [--parallel] [--warning-as-error] [--error-no-fail] [--result-file RESULT_FILE]
+                  [--result-format RESULT_FORMAT]
 
 required arguments:
   --project PROJECT                   project to generate from
@@ -34,6 +35,9 @@ optional arguments:
   --macro MACRO                       macro to define. The format is --macro=<name>::<value>
 
   --plugin-location PLUGIN_LOCATION   location to load additional plugins from
+
+  --plugin-root PLUGIN_ROOT           directory to search for plugins in. This detection method is
+                                      independent from --plugin and --plugin-location
 
   --build-number BUILD_NUMBER         build number used to determine if the plugins are compatible
 

--- a/modelcheck/README.md
+++ b/modelcheck/README.md
@@ -16,8 +16,8 @@ The simplest way to run it is by using Gradle's `JavaExec` task. See below for a
 
 ```
 usage: modelcheck [-h] [--plugin PLUGIN]... [--macro MACRO]... [--plugin-location PLUGIN_LOCATION]
-                  [--build-number BUILD_NUMBER] --project PROJECT [--test-mode]
-                  [--environment ENVIRONMENT] [--log-level LOG_LEVEL] [--model MODEL]...
+                  [--build-number BUILD_NUMBER] [--test-mode] [--environment ENVIRONMENT]
+                  [--log-level LOG_LEVEL] [--no-libraries] --project PROJECT [--model MODEL]...
                   [--module MODULE]... [--exclude-model EXCLUDE_MODEL]...
                   [--exclude-module EXCLUDE_MODULE]... [--parallel] [--warning-as-error]
                   [--error-no-fail] [--result-file RESULT_FILE] [--result-format RESULT_FORMAT]
@@ -29,7 +29,7 @@ required arguments:
 optional arguments:
   -h, --help                          show this help message and exit
 
-  --plugin PLUGIN                     plugin to to load. The format is --plugin=<id>::<path>
+  --plugin PLUGIN                     plugin to load. The format is --plugin=<id>::<path>
 
   --macro MACRO                       macro to define. The format is --macro=<name>::<value>
 
@@ -44,6 +44,8 @@ optional arguments:
 
   --log-level LOG_LEVEL               console log level. Supported values: info, warn, error, off.
                                       Default: warn.
+
+  --no-libraries                      do not load project libraries under MPS environment
 
   --model MODEL                       list of models to check (regexes)
 

--- a/project-loader/CHANGELOG.md
+++ b/project-loader/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Changes in versions before 2.0.0 are documented in the [root changelog](../CHANGELOG.md).
 
+## 2.3.0
+
+### Added
+
+- Load project libraries from `.mps/libraries.xml` under the project directory when using MPS environment (can be 
+  disabled via `--no-libraries`).
+- New `--plugin-root` argument. Automatically detect plugins in subdirectories of plugin roots.
+
 ## 2.2.0
 
 ### Added

--- a/project-loader/api/project-loader.api
+++ b/project-loader/api/project-loader.api
@@ -19,6 +19,7 @@ public final class de/itemis/mps/gradle/logging/LoggingFactoryKt {
 
 public class de/itemis/mps/gradle/project/loader/Args : de/itemis/mps/gradle/project/loader/EnvironmentArgs {
 	public fun <init> (Lcom/xenomachina/argparser/ArgParser;)V
+	public fun configureProjectLoader (Lde/itemis/mps/gradle/project/loader/ProjectLoader$Builder;)V
 	public final fun getProject ()Ljava/io/File;
 }
 
@@ -36,6 +37,7 @@ public class de/itemis/mps/gradle/project/loader/EnvironmentArgs {
 	public final fun getMacros ()Ljava/util/List;
 	public final fun getPluginLocation ()Ljava/io/File;
 	public final fun getPlugins ()Ljava/util/List;
+	public final fun getSkipLibraries ()Z
 	public final fun getTestMode ()Z
 }
 
@@ -43,6 +45,7 @@ public final class de/itemis/mps/gradle/project/loader/EnvironmentConfigBuilder 
 	public fun <init> ()V
 	public final fun build ()Ljetbrains/mps/tool/environment/EnvironmentConfig;
 	public final fun getInitialConfig ()Ljetbrains/mps/tool/environment/EnvironmentConfig;
+	public final fun getLibraries ()Ljava/util/List;
 	public final fun getMacros ()Ljava/util/List;
 	public final fun getPluginLocation ()Ljava/io/File;
 	public final fun getPlugins ()Ljava/util/List;

--- a/project-loader/api/project-loader.api
+++ b/project-loader/api/project-loader.api
@@ -36,6 +36,7 @@ public class de/itemis/mps/gradle/project/loader/EnvironmentArgs {
 	public final fun getLogLevel ()Lde/itemis/mps/gradle/logging/LogLevel;
 	public final fun getMacros ()Ljava/util/List;
 	public final fun getPluginLocation ()Ljava/io/File;
+	public final fun getPluginRoots ()Ljava/util/List;
 	public final fun getPlugins ()Ljava/util/List;
 	public final fun getSkipLibraries ()Z
 	public final fun getTestMode ()Z

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -43,6 +43,12 @@ dependencies {
     testImplementation("junit:junit:4.13.1")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 kotlin {
     explicitApi()
 }

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/EnvironmentConfigBuilder.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/EnvironmentConfigBuilder.kt
@@ -7,6 +7,7 @@ import java.io.File
 public class EnvironmentConfigBuilder {
     public var initialConfig: EnvironmentConfig = basicEnvironmentConfig()
     public val plugins: MutableList<Plugin> = mutableListOf()
+    public val libraries: MutableList<String> = mutableListOf()
     public var pluginLocation: File? = null
     public var macros: MutableList<Macro> = mutableListOf()
     public var testMode: Boolean = false
@@ -30,6 +31,9 @@ public class EnvironmentConfigBuilder {
                 cfg.addPreInstalledPlugin(it.path, it.id)
             }
         }
+
+        libraries.forEach { cfg.addLib(it) }
+
         macros.forEach { cfg.addMacro(it.name, File(it.value)) }
 
         if (testMode) cfg.withTestModeOn()

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/PluginIds.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/PluginIds.kt
@@ -16,7 +16,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.isDirectory
 
-private val logger = detectLogging().getLogger("de.itemis.mps.gradle.tasks.PluginIds")
+private val logger = detectLogging().getLogger("de.itemis.mps.gradle.project.loader.PluginIds")
 
 internal fun findPluginsRecursively(root: Path): List<Plugin> = mutableListOf<Plugin>().apply {
     if (!root.isDirectory()) {

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/PluginIds.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/PluginIds.kt
@@ -1,0 +1,126 @@
+package de.itemis.mps.gradle.project.loader
+
+import de.itemis.mps.gradle.logging.detectLogging
+import org.w3c.dom.Document
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.jar.JarFile
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.isDirectory
+
+private val logger = detectLogging().getLogger("de.itemis.mps.gradle.tasks.PluginIds")
+
+internal fun findPluginsRecursively(root: Path): List<Plugin> = mutableListOf<Plugin>().apply {
+    if (!root.isDirectory()) {
+        logger.warn("Plugin root is not a directory: $root")
+    }
+
+    Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
+        override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
+            val dirAsFile = dir.toFile()
+            val id = readPluginId(dirAsFile)
+            if (id != null) {
+                this@apply.add(Plugin(id, dir.absolutePathString()))
+                return FileVisitResult.SKIP_SUBTREE
+            }
+            return FileVisitResult.CONTINUE
+        }
+    })
+}.toList()
+
+internal fun readPluginId(pluginDirectory: File): String? {
+    logger.debug("Reading plugin ID for $pluginDirectory")
+    val pluginXml = findPluginDescriptor(pluginDirectory) ?: return null
+    val ids = pluginXml.documentElement.getElementsByTagName("id")
+    if (ids.length != 1) {
+        logger.debug("Expected a single 'id' element, found ${ids.length}")
+        return null
+    }
+
+    val result = ids.item(0).textContent
+    logger.debug("Found ID: $result")
+    return result.ifBlank { null }
+}
+
+private fun findPluginDescriptor(pluginDirectory: File): Document? {
+    logger.debug("Looking for plugin descriptor in $pluginDirectory")
+    val libDir = pluginDirectory.resolve("lib")
+
+    if (libDir.isDirectory) {
+        val jarsInLib = libDir.listFiles { file -> file.name.endsWith(".jar") && file.isFile }
+
+        if (jarsInLib != null) {
+            for (jar in jarsInLib) {
+                val descriptor = readDescriptorFromJarFile(jar)
+                if (descriptor != null) {
+                    logger.debug("Found plugin descriptor inside $jar")
+                    return descriptor
+                }
+            }
+        }
+    }
+
+    val pluginXmlFile = pluginDirectory.resolve("META-INF/plugin.xml")
+    if (pluginXmlFile.isFile) {
+        logger.debug("Found plugin descriptor in $pluginXmlFile")
+        return readXmlFile(pluginXmlFile)
+    }
+
+    logger.debug("Plugin descriptor not found in $pluginDirectory")
+    return null
+}
+
+private fun readDescriptorFromJarFile(file: File): Document? {
+    try {
+        JarFile(file).use { jarFile ->
+            val jarEntry = jarFile.getJarEntry("META-INF/plugin.xml") ?: return null
+            jarFile.getInputStream(jarEntry).use {
+                return readXmlFile(it, "${file}!${jarEntry.name}")
+            }
+        }
+    } catch (ex: IOException) {
+        logger.warn("Error reading JAR file $file", ex)
+        return null
+    }
+}
+
+private fun readXmlFile(file: File): Document? {
+    return try {
+        newDocumentBuilder().parse(file)
+    } catch (e: Exception) {
+        logger.warn("Error reading $file", e)
+        null
+    }
+}
+
+private fun readXmlFile(stream: InputStream, name: String): Document? {
+    return try {
+        newDocumentBuilder().parse(stream, name)
+    } catch (e: Exception) {
+        logger.warn("Error reading $name", e)
+        null
+    }
+}
+
+private fun newDocumentBuilder(): DocumentBuilder {
+    val dbf = DocumentBuilderFactory.newInstance()
+    disableDTD(dbf)
+    return dbf.newDocumentBuilder()
+}
+
+private fun disableDTD(dbf: DocumentBuilderFactory) {
+    dbf.isValidating = false;
+    dbf.isNamespaceAware = true;
+    dbf.setFeature("http://xml.org/sax/features/namespaces", false);
+    dbf.setFeature("http://xml.org/sax/features/validation", false);
+    dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+    dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+}

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLibraries.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLibraries.kt
@@ -1,0 +1,39 @@
+package de.itemis.mps.gradle.project.loader
+
+import de.itemis.mps.gradle.logging.detectLogging
+import java.io.File
+
+private val logger = detectLogging().getLogger("de.itemis.mps.gradle.project.loader.ProjectLibraries")
+
+internal fun findProjectLibraries(projectLocation: File, macros: List<Macro>, onFound: (Sequence<String>) -> Unit) {
+    val librariesXml = projectLocation.resolve(".mps/libraries.xml")
+    if (!librariesXml.exists()) return
+
+    val macroMap = macros.associate { it.name to it.value }
+    val pathRegex = Regex("""<option\s+name=['"]path['"]\s+value=['"](.*?)['"]\s*/>""")
+    librariesXml.useLines { lines ->
+        val libraryPaths = lines
+            .mapNotNull { pathRegex.find(it)?.groupValues?.get(1) }
+            .map { expandMacros(macroMap, it) }
+
+        logger.info("Found libraries in $librariesXml: $libraryPaths")
+        onFound(libraryPaths)
+    }
+}
+
+private fun expandMacros(macros: Map<String, String>, input: String): String {
+    if (!input.startsWith("\${")) return input
+
+    val macroLastChar = input.indexOf('}')
+    if (macroLastChar < 0) return input // malformed
+
+    val macroKey = input.substring(2, macroLastChar)
+    val macroValue = macros[macroKey]
+
+    if (macroValue == null) {
+        logger.warn("Unknown macro: $macroKey")
+        return input
+    }
+
+    return macroValue + input.substring(macroLastChar + 1)
+}

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLoader.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLoader.kt
@@ -7,7 +7,6 @@ import jetbrains.mps.tool.environment.Environment
 import jetbrains.mps.tool.environment.EnvironmentConfig
 import jetbrains.mps.tool.environment.IdeaEnvironment
 import jetbrains.mps.tool.environment.MpsEnvironment
-import org.apache.log4j.Logger
 import java.io.File
 
 /**
@@ -20,7 +19,7 @@ public class ProjectLoader private constructor(
     private val buildNumber: String?,
     private val logLevel: LogLevel
 ) {
-    private val logger = Logger.getLogger("de.itemis.mps.gradle.project.loader")
+    private val logger = detectLogging().getLogger("de.itemis.mps.gradle.project.loader")
 
     public class Builder {
         /**

--- a/project-loader/src/test/kotlin/de/itemis/mps/gradle/project/loader/PluginIdsTest.kt
+++ b/project-loader/src/test/kotlin/de/itemis/mps/gradle/project/loader/PluginIdsTest.kt
@@ -1,0 +1,72 @@
+package de.itemis.mps.gradle.project.loader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+
+class PluginIdsTest {
+
+    @JvmField @Rule
+    val folder = TemporaryFolder()
+
+    @Test
+    fun idInLibJar() {
+        val pluginDir = folder.newFolder()
+        writeJarWithPluginXml(pluginDir.resolve("lib/myjar.jar"), "<idea-plugin><id>jetbrains.jetpad</id></idea-plugin>")
+
+        assertEquals("jetbrains.jetpad", readPluginId(pluginDir))
+    }
+
+
+    @Test
+    fun noDescriptor() {
+        val pluginDir = folder.newFolder()
+        assertNull(readPluginId(pluginDir))
+    }
+
+    @Test
+    fun idInMetaInf() {
+        val pluginDir = folder.newFolder()
+        writeTextFile(pluginDir.resolve("META-INF/plugin.xml"), "<idea-plugin><id>jetbrains.jetpad</id></idea-plugin>")
+
+        assertEquals("jetbrains.jetpad", readPluginId(pluginDir))
+    }
+
+    @Test
+    fun idInLibJarTakesPrecedence() {
+        val pluginDir = folder.newFolder()
+        writeJarWithPluginXml(pluginDir.resolve("lib/foo.jar"), "<idea-plugin><id>foo</id></idea-plugin>")
+        writeTextFile(pluginDir.resolve("META-INF/plugin.xml"), "<idea-plugin><id>bar</id></idea-plugin>")
+
+        assertEquals("foo", readPluginId(pluginDir))
+    }
+
+    @Test
+    fun invalidXml() {
+        val pluginDir = folder.newFolder()
+        writeJarWithPluginXml(pluginDir.resolve("lib/foo.jar"), "INVALID")
+
+        assertNull(readPluginId(pluginDir))
+    }
+
+    private fun writeTextFile(metaInfPluginXml: File, contents: String) {
+        metaInfPluginXml.parentFile.mkdirs()
+                || throw RuntimeException("Could not create parent directory for $metaInfPluginXml")
+
+        metaInfPluginXml.writeText(contents)
+    }
+
+    private fun writeJarWithPluginXml(jarFile: File, contents: String) {
+        jarFile.parentFile.mkdirs() || throw RuntimeException("Could not create parent directory for $jarFile")
+
+        JarOutputStream(jarFile.outputStream()).use {
+            it.putNextEntry(JarEntry("META-INF/plugin.xml"))
+            it.write(contents.toByteArray())
+        }
+    }
+}

--- a/project-loader/src/test/kotlin/de/itemis/mps/gradle/project/loader/ProjectLibrariesTest.kt
+++ b/project-loader/src/test/kotlin/de/itemis/mps/gradle/project/loader/ProjectLibrariesTest.kt
@@ -1,0 +1,107 @@
+package de.itemis.mps.gradle.project.loader
+
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+private const val Macro1 = "\${macro.path1}"
+private const val Macro2 = "\${macro.path2}"
+private val AllMacros = listOf(
+    Macro("macro.path1", "/path/to/macro1"),
+    Macro("macro.path2", "/path/to/macro2")
+)
+
+class ProjectLibrariesTest {
+
+    @JvmField @Rule
+    val folder = TemporaryFolder()
+
+    @Test
+    fun noLibrariesXml() {
+        assertEquals(emptyList<String>(), getLibraries())
+    }
+
+    @Test
+    fun emptyLibrariesXml() {
+        writeFile(text = "<map/>")
+        assertEquals(emptyList<String>(), getLibraries())
+    }
+
+    @Test
+    fun librariesWithoutMacros() {
+        writeFile(text = """<map>
+            <Library>
+                <option name="name" value="dependencies1" />
+                <option name="path" value="/path/to/dependencies1" />
+            </Library>
+            <Library>
+                <option name="name" value="dependencies2" />
+                <option name="path" value="/path/to/dependencies2" />
+            </Library>
+        </map>""")
+
+        assertEquals(listOf("/path/to/dependencies1", "/path/to/dependencies2"), getLibraries())
+    }
+
+    @Test
+    fun macrosNotFound() {
+        writeFile(text = """<map>
+            <Library>
+                <option name="name" value="dependencies1" />
+                <option name="path" value="${Macro1}/dependencies1" />
+            </Library>
+            <Library>
+                <option name="name" value="dependencies2" />
+                <option name="path" value="${Macro2}/dependencies2" />
+            </Library>
+        </map>""")
+
+        assertEquals(listOf("\${macro.path1}/dependencies1", "\${macro.path2}/dependencies2"), getLibraries())
+    }
+
+    @Test
+    fun macrosFound() {
+        writeFile(text = """<map>
+            <Library>
+                <option name="name" value="dependencies1" />
+                <option name="path" value="${Macro1}/dependencies1" />
+            </Library>
+            <Library>
+                <option name="name" value="dependencies2" />
+                <option name="path" value="${Macro2}/dependencies2" />
+            </Library>
+        </map>""")
+
+        assertEquals(listOf("/path/to/macro1/dependencies1", "/path/to/macro2/dependencies2"), getLibraries(AllMacros))
+    }
+
+    @Test
+    fun macrosOnlyInPrefix() {
+        writeFile(text = """<map>
+            <Library>
+                <option name="name" value="dependencies1" />
+                <option name="path" value="/home/${Macro1}/dependencies1" />
+            </Library>
+            <Library>
+                <option name="name" value="dependencies2" />
+                <option name="path" value="/home/${Macro2}/dependencies2" />
+            </Library>
+        </map>""")
+
+        assertEquals(listOf("/home/\${macro.path1}/dependencies1", "/home/\${macro.path2}/dependencies2"),
+            getLibraries(AllMacros))
+    }
+
+    private fun getLibraries(macros: List<Macro> = emptyList()): List<String> {
+        var result: List<String> = emptyList()
+        findProjectLibraries(folder.root, macros) { result = it.toList() }
+        return result
+    }
+
+    private fun writeFile(filePath: String = ".mps/libraries.xml", text: String) {
+        val fullPath = folder.root.resolve(filePath)
+        fullPath.parentFile.mkdirs()
+        fullPath.writeText(text)
+    }
+}


### PR DESCRIPTION
Changes:

* project-loader: load project libraries in MPS environment. Can be turned off with `--no-libraries`
* project-loader: `--project-root` directory to automatically detect plugins