### PR TITLE
Adding the ability to bypass reconciliation and compilation phases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.16.0
+
+### Added
+
+* `execute-generators`: added `--skip-reconciliation` and `--skip-compilation` options to reduce the total build time for certain large model use cases.
+
 ## 1.15.1
 
 ### Changed

--- a/execute-generators/README.md
+++ b/execute-generators/README.md
@@ -63,6 +63,11 @@ optional arguments:
   --parallel-generation-threads THREADS   Number of threads to use for parallel generation. Value
                                           of 0 means that parallel generation is disabled.
                                           Default: 0
+                                          
+  --skip-reconciliation                   skips the Make.reconcile target.
+  
+  --skip-compilation                      skips the Javacompile.compile target.                     
+                                          
 ```
 
 ## Error exit codes

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/GenerateArgs.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/GenerateArgs.kt
@@ -10,6 +10,8 @@ class GenerateArgs(parser: ArgParser) : Args(parser) {
     val modules by parser.adding("--module", help = "list of modules to generate")
     val excludeModels by parser.adding("--exclude-model", help = "list of models to exclude from generation")
     val excludeModules by parser.adding("--exclude-module", help = "list of modules to exclude from generation")
+    val skipReconciliation by parser.flagging("--skip-reconciliation", help = "skips the Make.reconcile target")
+    val skipCompilation by parser.flagging("--skip-compilation", help = "skips the JavaCompile.compile target")
     val noStrictMode by parser.flagging(
         "--no-strict-mode",
         help = "Disable strict generation mode. Strict mode places additional limitations on generators, but is required for parallel generation"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version.backend=1.15.1
+version.backend=1.16.0
 version.project-loader=2.3.0


### PR DESCRIPTION
As far as I can see the **reconciliation** phase doesn't really offer anything in the use case of execute-generators in a headless environment. Please correct me if this is wrong.

I have a use case where my generation phase takes 60 seconds, the reconciliation is ALSO taking 70+ seconds, so I'd very much like the ability to opt-out of that stage. This wasn't an issue for me when using the old Ant GenerateTask as that just did pure Generation, no mention of reconciliation.

Similarly, I've added the ability to opt-out of Java compilation since my source_gen is compiled externally. I know that it can be defined at the Solution level whether or not compilation is needed, but I think it is nicer to be able to have the model compiled if made from the IDE, but not compiled if Made through CLI.



