### PR TITLE
1.19.0: Support for 2024.1 and 2024.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.19.0
+
+- The backends are now tested against MPS 2024.1.1 and MPS 2024.3 and not tested anymore for versions before 2022.3.
+
+- `modelcheck`: instead of adding `UnresolvedReferencesChecker` to the list of checkers, the `mps-modelchecker` plugin
+  (which contains this checker) is always loaded instead.
+
 ## 1.18.0
 
 - `modelcheck`: Work around an indexing problem in MPS 2023.2 and above (build number 232.xxx or higher) by triggering

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version.backend=1.18.0
+version.backend=1.19.0
 version.project-loader=2.3.1

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     execute(project(":execute"))
 }
 
-val SUPPORTED_MPS_VERSIONS = arrayOf("2021.3.5", "2022.2.2", "2022.3.2", "2023.2", "2023.3")
+val SUPPORTED_MPS_VERSIONS = arrayOf("2022.3.3", "2023.2.2", "2024.1.1", "2024.3")
 
 val GENERATION_TESTS = listOf(
     GenerationTest("generateBuildSolution", "generate-build-solution", listOf("--model", "my.build.script"),
@@ -300,7 +300,6 @@ fun tasksForMpsVersion(mpsVersion: String): Multimap<TestKind, TaskProvider<out 
                 include("lib/**/*.jar")
                 // modelcheck uses HttpSupportUtil#getURL()
                 include("plugins/mps-httpsupport/**/*.jar")
-                include("plugins/mps-modelchecker/**/*.jar")
             })
             classpath(modelcheck)
 

--- a/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheck.kt
+++ b/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheck.kt
@@ -18,7 +18,6 @@ import jetbrains.mps.errors.MessageStatus
 import jetbrains.mps.errors.item.IssueKindReportItem
 import jetbrains.mps.ide.httpsupport.runtime.base.HttpSupportUtil
 import jetbrains.mps.ide.modelchecker.platform.actions.IdeaPlatformReadExecutor
-import jetbrains.mps.ide.modelchecker.platform.actions.UnresolvedReferencesChecker
 import jetbrains.mps.progress.EmptyProgressMonitor
 import jetbrains.mps.project.MPSProject
 import jetbrains.mps.project.Project
@@ -313,9 +312,6 @@ private fun ModelCheckerBuilder.setParallelTaskSchedulerV1(project: Project) {
 
 fun modelCheckProject(args: ModelCheckArgs, environment: Environment, project: Project): Boolean {
     val checkers = environment.platform.findComponent(CheckerRegistry::class.java)!!.checkers
-    if (checkers.all { it !is UnresolvedReferencesChecker }) {
-        checkers.add(UnresolvedReferencesChecker())
-    }
 
     if (logger.isInfoEnabled) {
         logger.info(checkers.joinToString(prefix = "Found the following checkers in CheckerRegistry: "))

--- a/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheck.kt
+++ b/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheck.kt
@@ -337,7 +337,7 @@ fun modelCheckProject(args: ModelCheckArgs, environment: Environment, project: P
 
     // Workaround for https://youtrack.jetbrains.com/issue/MPS-37926/Indices-not-built-properly-in-IdeaEnvironment
     if (project is MPSProject && shouldForceIndexing(args, BuildNumber.currentVersion())) {
-        logger.info("Forcing full indexing to work around MPS-37926")
+        logger.info("Forcing full indexing to work around MPS-37926. Can be disabled with --force-indexing=never.")
         ApplicationManager.getApplication().invokeAndWait({
             ApplicationManager.getApplication().runWriteAction {
                 ProjectRootManagerEx.getInstanceEx(project.project)

--- a/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheckArgs.kt
+++ b/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheckArgs.kt
@@ -3,6 +3,8 @@ package de.itemis.mps.gradle.modelcheck
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.default
 import de.itemis.mps.gradle.project.loader.Args
+import de.itemis.mps.gradle.project.loader.Plugin
+import de.itemis.mps.gradle.project.loader.ProjectLoader
 import kotlin.test.fail
 
 @Suppress("DEPRECATION")
@@ -36,4 +38,10 @@ class ModelCheckArgs(parser: ArgParser) : Args(parser) {
             else -> fail("Unsupported value '$this'. Supported values are always, never, auto")
         }
     }.default(null)
+
+    override fun configureProjectLoader(builder: ProjectLoader.Builder) {
+        builder.environmentConfig {
+            plugins.add(Plugin("jetbrains.mps.ide.modelchecker", "mps-modelchecker"))
+        }
+    }
 }


### PR DESCRIPTION
Load `mps-modelchecker` plugin instead of explicitly adding just `UnresolvedReferencesChecker` to the checker list.