### PR TITLE
1.24.1: fail generation if any error was reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.24.1
+
+- `execute-generators`: return generation failed status in case of any reported errors during the generation, 
+independent of the generation result, which might still be successful (consistent with the generator behavior in MPS 
+generated Ant scripts).
+
 ## 1.24.0
 
 - `modelcheck`: Include the model stereotype when matching (`--model` and `--exclude-model` parameters) and in the JUnit

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=true
 
-version.backend=1.24.0
+version.backend=1.24.1
 version.project-loader=3.0.2
 
 # A comma-separated list of MPS releases or prereleases to test against.


### PR DESCRIPTION
Return generation failed status in case of any reported errors during the generation, independent of the generation result, which might still be successful (consistent with the generator behavior in MPS generated Ant scripts).