### PR TITLE
feat(execute,project-loader): use indexing workaround in all backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.24.2
+
+- `execute` now applies the indexing workaround like `modelcheck` and `generate`.
+- `project-loader` dependency bumped to 4.0.0.
+
 ## 1.24.1
 
 - `execute-generators`: return generation failed status in case of any reported errors during the generation, 

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/GenerateArgs.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/GenerateArgs.kt
@@ -1,7 +1,6 @@
 package de.itemis.mps.gradle.generate
 
 import com.xenomachina.argparser.ArgParser
-import com.xenomachina.argparser.InvalidArgumentException
 import com.xenomachina.argparser.default
 import de.itemis.mps.gradle.project.loader.Args
 import de.itemis.mps.gradle.project.loader.checkArgument
@@ -25,14 +24,4 @@ class GenerateArgs(parser: ArgParser) : Args(parser) {
         .addValidator {
             checkArgument(!noStrictMode || value == 0) { "strict mode is required for parallel generation" }
         }
-    val forceIndexing by parser.storing(
-        "--force-indexing", help = "whether to force full indexing at startup to work around MPS-37926." +
-                " Supported values: always, never, auto. Default: auto.") {
-        when (this) {
-            "always" -> true
-            "never" -> false
-            "auto" -> null
-            else -> throw InvalidArgumentException("Unsupported value '$this'. Supported values are always, never, auto")
-        }
-    }.default(null)
 }

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Helper.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Helper.kt
@@ -1,14 +1,10 @@
 package de.itemis.mps.gradle.generate
 
 
-import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.util.BuildNumber
 import com.intellij.openapi.util.IconLoader
 import de.itemis.mps.gradle.logging.detectLogging
 import de.itemis.mps.gradle.project.loader.EnvironmentKind
 import de.itemis.mps.gradle.project.loader.ModuleAndModelMatcher
-import de.itemis.mps.gradle.project.loader.forceIndexing
-import de.itemis.mps.gradle.project.loader.hasIndexingBug
 import jetbrains.mps.generator.GenerationSettingsProvider
 import jetbrains.mps.generator.runtime.TemplateModule
 import jetbrains.mps.make.MakeSession
@@ -20,7 +16,6 @@ import jetbrains.mps.make.script.ScriptBuilder
 import jetbrains.mps.messages.IMessage
 import jetbrains.mps.messages.IMessageHandler
 import jetbrains.mps.messages.MessageKind
-import jetbrains.mps.project.MPSProject
 import jetbrains.mps.project.Project
 import jetbrains.mps.smodel.ModelAccessHelper
 import jetbrains.mps.smodel.SLanguageHierarchy
@@ -210,17 +205,6 @@ private fun makeModels(proj: Project, models: List<SModel>): GenerationResult {
 
 
 fun generateProject(parsed: GenerateArgs, project: Project): GenerationResult {
-
-    // Workaround for https://youtrack.jetbrains.com/issue/MPS-37926/Indices-not-built-properly-in-IdeaEnvironment
-    if (project is MPSProject) {
-        val buildNumber = ApplicationInfo.getInstance().build
-        if (shouldForceIndexing(parsed, buildNumber)) {
-            logger.info("Forcing full indexing to work around MPS-37926. Can be disabled with --force-indexing=never.")
-            forceIndexing(project, buildNumber)
-            logger.info("Full indexing complete")
-        }
-    }
-
     val generationSettings = project.getComponent(GenerationSettingsProvider::class.java).generationSettings
     parsed.parallelGenerationThreads.let {
         when {
@@ -261,8 +245,4 @@ fun generateProject(parsed: GenerateArgs, project: Project): GenerationResult {
     }
 
     return makeModels(project, modelsToGenerate)
-}
-
-private fun shouldForceIndexing(args: GenerateArgs, buildNumber: BuildNumber): Boolean {
-    return args.forceIndexing ?: hasIndexingBug(buildNumber)
 }

--- a/execute/README.md
+++ b/execute/README.md
@@ -16,7 +16,8 @@ read and write locks itself, for example with `jetbrains.mps.lang.access`.
 usage: execute [-h] [--plugin PLUGIN]... [--macro MACRO]... [--plugin-location PLUGIN_LOCATION]
                [--plugin-root PLUGIN_ROOT]... [--build-number BUILD_NUMBER] [--test-mode]
                [--environment ENVIRONMENT] [--log-level LOG_LEVEL] [--no-libraries]
-               --project PROJECT --module MODULE --class CLASS --method METHOD [--arg ARG]...
+               --project PROJECT [--force-indexing FORCE_INDEXING] --module MODULE --class CLASS
+               --method METHOD [--arg ARG]...
 
 required arguments:
   --project PROJECT                   project to generate from
@@ -53,6 +54,10 @@ optional arguments:
                                       Default: warn.
 
   --no-libraries                      do not load project libraries under MPS environment
+
+  --force-indexing FORCE_INDEXING     whether to force full indexing at startup to work around
+                                      MPS-37926. Supported values: always, never, auto. Default:
+                                      auto.
 
   --arg ARG                           list of strings to pass to the method. Allowed only if the
                                       method signature is (Project, String[])

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 
-version.backend=1.24.1
-version.project-loader=3.0.2
+version.backend=1.24.2
+version.project-loader=4.0.0
 
 # A comma-separated list of MPS releases or prereleases to test against.
 supportedMpsVersions=2022.3.3,2023.2.2,2024.1.2,2024.3.1,251.23774.10091

--- a/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheck.kt
+++ b/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheck.kt
@@ -1,18 +1,10 @@
 package de.itemis.mps.gradle.modelcheck
 
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.util.BuildNumber
-import de.itemis.mps.gradle.junit.Failure
-import de.itemis.mps.gradle.junit.JUnitXmlSerializer
-import de.itemis.mps.gradle.junit.Testcase
-import de.itemis.mps.gradle.junit.Testsuite
-import de.itemis.mps.gradle.junit.Testsuites
+import de.itemis.mps.gradle.junit.*
 import de.itemis.mps.gradle.logging.detectLogging
 import de.itemis.mps.gradle.project.loader.ModuleAndModelMatcher
-import de.itemis.mps.gradle.project.loader.forceIndexing
-import de.itemis.mps.gradle.project.loader.hasIndexingBug
 import jetbrains.mps.checkers.ModelCheckerBuilder
 import jetbrains.mps.errors.CheckerRegistry
 import jetbrains.mps.errors.MessageStatus
@@ -20,7 +12,6 @@ import jetbrains.mps.errors.item.IssueKindReportItem
 import jetbrains.mps.ide.httpsupport.runtime.base.HttpSupportUtil
 import jetbrains.mps.ide.modelchecker.platform.actions.IdeaPlatformReadExecutor
 import jetbrains.mps.progress.EmptyProgressMonitor
-import jetbrains.mps.project.MPSProject
 import jetbrains.mps.project.Project
 import jetbrains.mps.smodel.ModelAccessBase
 import jetbrains.mps.smodel.SModelStereotype
@@ -337,16 +328,6 @@ fun modelCheckProject(args: ModelCheckArgs, environment: Environment, project: P
     modelExtractor.includeStubs(false)
     val itemsToCheck = ModelCheckerBuilder.ItemsToCheck()
 
-    // Workaround for https://youtrack.jetbrains.com/issue/MPS-37926/Indices-not-built-properly-in-IdeaEnvironment
-    if (environment is IdeaEnvironment) {
-        val buildNumber = ApplicationInfo.getInstance().build
-        if (shouldForceIndexing(args, buildNumber)) {
-            logger.info("Forcing full indexing. Can be disabled with --force-indexing=never.")
-            forceIndexing(project as MPSProject, buildNumber)
-            logger.info("Full indexing complete")
-        }
-    }
-
     // In the IDEA environment run the model check in EDT to avoid interference from other code that may want to run
     // a write or read action, such as 'run in smart mode' callbacks triggered by completed indexing, context assistant
     // updates, etc.
@@ -405,8 +386,4 @@ fun modelCheckProject(args: ModelCheckArgs, environment: Environment, project: P
 
     val minSeverity = if (args.warningAsError) MessageStatus.WARNING else MessageStatus.ERROR
     return errorCollector.result.any { it.severity >= minSeverity }
-}
-
-fun shouldForceIndexing(args: ModelCheckArgs, buildNumber: BuildNumber): Boolean {
-    return args.forceIndexing ?: hasIndexingBug(buildNumber)
 }

--- a/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheckArgs.kt
+++ b/modelcheck/src/main/kotlin/de/itemis/mps/gradle/modelcheck/ModelCheckArgs.kt
@@ -27,17 +27,6 @@ class ModelCheckArgs(parser: ArgParser) : Args(parser) {
         }
     }.default(ReportFormat.ONE_TEST_PER_MODEL)
 
-    val forceIndexing by parser.storing(
-        "--force-indexing", help = "whether to force full indexing at startup to work around MPS-37926." +
-                " Supported values: always, never, auto. Default: auto.") {
-        when (this) {
-            "always" -> true
-            "never" -> false
-            "auto" -> null
-            else -> throw IllegalArgumentException("Unsupported value '$this'. Supported values are always, never, auto")
-        }
-    }.default(null)
-
     override fun configureProjectLoader(builder: ProjectLoader.Builder) {
         super.configureProjectLoader(builder)
         builder.environmentConfig {

--- a/project-loader/CHANGELOG.md
+++ b/project-loader/CHANGELOG.md
@@ -7,6 +7,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Changes in versions before 2.0.0 are documented in the [root changelog](../CHANGELOG.md).
 
+## 4.0.0
+
+### Added
+
+- `Args#forceIndexing` added to control the application of the indexing workaround. This unifies the behavior of all
+  backends and extends the functionality to the `execute` backend that didn't have it before.
+
+### Removed
+
+- Methods in `IndexingWorkaround.kt` related to the indexing workaround logic are no longer public.
+
 ## 3.0.2
 
 ### Fixed

--- a/project-loader/api/project-loader.api
+++ b/project-loader/api/project-loader.api
@@ -20,6 +20,7 @@ public final class de/itemis/mps/gradle/logging/LoggingFactoryKt {
 public class de/itemis/mps/gradle/project/loader/Args : de/itemis/mps/gradle/project/loader/EnvironmentArgs {
 	public fun <init> (Lcom/xenomachina/argparser/ArgParser;)V
 	public fun configureProjectLoader (Lde/itemis/mps/gradle/project/loader/ProjectLoader$Builder;)V
+	public final fun getForceIndexing ()Ljava/lang/Boolean;
 	public final fun getProject ()Ljava/io/File;
 }
 
@@ -62,11 +63,6 @@ public final class de/itemis/mps/gradle/project/loader/EnvironmentKind : java/la
 	public static final field MPS Lde/itemis/mps/gradle/project/loader/EnvironmentKind;
 	public static fun valueOf (Ljava/lang/String;)Lde/itemis/mps/gradle/project/loader/EnvironmentKind;
 	public static fun values ()[Lde/itemis/mps/gradle/project/loader/EnvironmentKind;
-}
-
-public final class de/itemis/mps/gradle/project/loader/IndexingWorkaroundKt {
-	public static final fun forceIndexing (Ljetbrains/mps/project/MPSProject;Lcom/intellij/openapi/util/BuildNumber;)V
-	public static final fun hasIndexingBug (Lcom/intellij/openapi/util/BuildNumber;)Z
 }
 
 public final class de/itemis/mps/gradle/project/loader/LoaderKt {
@@ -122,7 +118,7 @@ public final class de/itemis/mps/gradle/project/loader/Plugin {
 
 public final class de/itemis/mps/gradle/project/loader/ProjectLoader {
 	public static final field Companion Lde/itemis/mps/gradle/project/loader/ProjectLoader$Companion;
-	public synthetic fun <init> (Ljetbrains/mps/tool/environment/EnvironmentConfig;Lde/itemis/mps/gradle/project/loader/EnvironmentKind;Ljava/io/File;Ljava/lang/String;Lde/itemis/mps/gradle/logging/LogLevel;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljetbrains/mps/tool/environment/EnvironmentConfig;Lde/itemis/mps/gradle/project/loader/EnvironmentKind;Ljava/io/File;Ljava/lang/String;Lde/itemis/mps/gradle/logging/LogLevel;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun execute (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun executeWithProject (Ljava/io/File;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
@@ -134,9 +130,11 @@ public final class de/itemis/mps/gradle/project/loader/ProjectLoader$Builder {
 	public final fun getBuildNumber ()Ljava/lang/String;
 	public final fun getEnvironmentConfigBuilder ()Lde/itemis/mps/gradle/project/loader/EnvironmentConfigBuilder;
 	public final fun getEnvironmentKind ()Lde/itemis/mps/gradle/project/loader/EnvironmentKind;
+	public final fun getForceIndexing ()Ljava/lang/Boolean;
 	public final fun getLogLevel ()Lde/itemis/mps/gradle/logging/LogLevel;
 	public final fun setBuildNumber (Ljava/lang/String;)V
 	public final fun setEnvironmentKind (Lde/itemis/mps/gradle/project/loader/EnvironmentKind;)V
+	public final fun setForceIndexing (Ljava/lang/Boolean;)V
 	public final fun setLogLevel (Lde/itemis/mps/gradle/logging/LogLevel;)V
 }
 

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/Args.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/Args.kt
@@ -4,7 +4,6 @@ import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.InvalidArgumentException
 import com.xenomachina.argparser.default
 import de.itemis.mps.gradle.logging.LogLevel
-import de.itemis.mps.gradle.logging.detectLogging
 import java.io.File
 import java.nio.file.Path
 
@@ -85,8 +84,21 @@ public open class Args(parser: ArgParser) : EnvironmentArgs(parser) {
     public val project: File by parser.storing("--project",
             help = "project to generate from") { File(this) }
 
+    public val forceIndexing: Boolean? by parser.storing(
+        "--force-indexing", help = "whether to force full indexing at startup to work around MPS-37926." +
+                " Supported values: always, never, auto. Default: auto.") {
+        when (this) {
+            "always" -> true
+            "never" -> false
+            "auto" -> null
+            else -> throw InvalidArgumentException("Unsupported value '$this'. Supported values are always, never, auto")
+        }
+    }.default(null)
+
     override fun configureProjectLoader(builder: ProjectLoader.Builder) {
         super.configureProjectLoader(builder)
+
+        builder.forceIndexing = forceIndexing
 
         if (!skipLibraries && environmentKind == EnvironmentKind.MPS) {
             builder.environmentConfig {

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/IndexingWorkaround.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/IndexingWorkaround.kt
@@ -11,7 +11,7 @@ import jetbrains.mps.project.MPSProject
 /**
  * Indicates whether the given MPS version has the indexing bug.
  */
-public fun hasIndexingBug(buildNumber: BuildNumber): Boolean {
+internal fun hasIndexingBug(buildNumber: BuildNumber): Boolean {
     // For 2023.2 we need to force indexing, for 2024.1 we only wait for indexing to complete using IndexingTestUtils.
     return buildNumber.baselineVersion >= 232
 }
@@ -19,7 +19,7 @@ public fun hasIndexingBug(buildNumber: BuildNumber): Boolean {
 /**
  * Force full indexing as a workaround for https://youtrack.jetbrains.com/issue/MPS-37926/Indices-not-built-properly-in-IdeaEnvironment
  */
-public fun forceIndexing(project: MPSProject, @Suppress("UNUSED_PARAMETER") buildNumber: BuildNumber) {
+internal fun forceIndexing(project: MPSProject, @Suppress("UNUSED_PARAMETER") buildNumber: BuildNumber) {
     try {
         forceIndexing241(project)
     } catch (e: NoClassDefFoundError) {

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLoader.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLoader.kt
@@ -1,7 +1,10 @@
 package de.itemis.mps.gradle.project.loader
 
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.BuildNumber
 import de.itemis.mps.gradle.logging.LogLevel
 import de.itemis.mps.gradle.logging.detectLogging
+import jetbrains.mps.project.MPSProject
 import jetbrains.mps.project.Project
 import jetbrains.mps.tool.environment.Environment
 import jetbrains.mps.tool.environment.EnvironmentConfig
@@ -17,7 +20,8 @@ public class ProjectLoader private constructor(
     private val environmentKind: EnvironmentKind,
     private val pluginLocation: File?,
     private val buildNumber: String?,
-    private val logLevel: LogLevel
+    private val logLevel: LogLevel,
+    private val forceIndexing: Boolean?
 ) {
     private val logger = detectLogging().getLogger("de.itemis.mps.gradle.project.loader")
 
@@ -40,12 +44,19 @@ public class ProjectLoader private constructor(
 
         public var logLevel: LogLevel = LogLevel.WARN
 
+        /**
+         * Whether to wait for indexing to complete after opening the project. Only has an effect in IDEA environments.
+         * When null, only wait if running a buggy MPS version (currently 2023.2 and above).
+         */
+        public var forceIndexing: Boolean? = null
+
         public fun build(): ProjectLoader = ProjectLoader(
             environmentConfigBuilder.build(),
             environmentKind,
             environmentConfigBuilder.pluginLocation,
             buildNumber,
-            logLevel
+            logLevel,
+            forceIndexing
         )
 
         /**
@@ -165,10 +176,20 @@ public class ProjectLoader private constructor(
 
         val project = environment.openProject(projectDir)
 
-        logger.info("flushing events")
-        environment.flushAllEvents()
-
         try {
+            logger.info("flushing events")
+            environment.flushAllEvents()
+
+            // Workaround for https://youtrack.jetbrains.com/issue/MPS-37926/Indices-not-built-properly-in-IdeaEnvironment
+            if (environment is IdeaEnvironment) {
+                val buildNumber = ApplicationInfo.getInstance().build
+                if (shouldForceIndexing(buildNumber)) {
+                    logger.info("Forcing full indexing. Can be disabled with --force-indexing=never.")
+                    forceIndexing(project as MPSProject, buildNumber)
+                    logger.info("Full indexing complete")
+                }
+            }
+
             return action(environment, project)
         } finally {
             logger.info("disposing project")
@@ -176,4 +197,9 @@ public class ProjectLoader private constructor(
             logger.info("project disposed")
         }
     }
+
+    private fun shouldForceIndexing(buildNumber: BuildNumber): Boolean {
+        return forceIndexing ?: hasIndexingBug(buildNumber)
+    }
 }
+


### PR DESCRIPTION
* Move forceIndexing flag from ModelCheckArgs and GenerateArgs to Args.
* Represent the flag in ProjectLoader and ProjectLoaderBuilder.
* Call the indexing workaround in ProjectLoader after opening a project.