### PR TITLE
Support for MPS 2025.3 prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.24.3
+
+- Upgrade to project-loader 4.0.0
+- Backends are now only tested against 2023.2 and above (up from 2022.2) due to a bug in MPS
+  (https://youtrack.jetbrains.com/issue/MPS-39248/Cant-find-property-constraints-errors-for-base-language)
+  which makes newer MPS versions break when opening projects from old MPS versions.
+
 ## 1.24.2
 
 - `execute` now applies the indexing workaround like `modelcheck` and `generate`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=true
 
-version.backend=1.24.2
+version.backend=1.24.3
 version.project-loader=5.0.0
 
 # A comma-separated list of MPS releases or prereleases to test against.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 
 version.backend=1.24.2
-version.project-loader=4.0.0
+version.project-loader=5.0.0
 
 # A comma-separated list of MPS releases or prereleases to test against.
 # Also used in the GitHub workflow to test each version in parallel

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ version.project-loader=4.0.0
 
 # A comma-separated list of MPS releases or prereleases to test against.
 # Also used in the GitHub workflow to test each version in parallel
-supportedMpsVersions=2022.3.3,2023.2.2,2024.1.2,2024.3.1,251.23774.10091
+supportedMpsVersions=2023.2.2,2024.1.2,2025.1.1,253.28294.219

--- a/launcher/CHANGELOG.md
+++ b/launcher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.8.0
+
+### Added
+
+- `--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED` is now passed to the JVM to support MPS 2025.3 prerelease.
+
 ## 2.7.0
 
 ### Changed

--- a/launcher/gradle.properties
+++ b/launcher/gradle.properties
@@ -1,1 +1,1 @@
-version.launcher=2.7.0
+version.launcher=2.8.0

--- a/launcher/src/main/java/de/itemis/mps/gradle/launcher/MpsBackendBuilder.java
+++ b/launcher/src/main/java/de/itemis/mps/gradle/launcher/MpsBackendBuilder.java
@@ -23,7 +23,6 @@ import org.gradle.process.JavaForkOptions;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
-import java.io.Serializable;
 import java.util.ArrayList;
 
 public class MpsBackendBuilder {
@@ -193,6 +192,7 @@ public class MpsBackendBuilder {
                 "java.base/java.util",
                 "java.base/java.util.concurrent",
                 "java.base/java.util.concurrent.atomic",
+                "java.base/jdk.internal.ref",
                 "java.base/jdk.internal.vm",
                 "java.base/sun.nio.ch",
                 "java.base/sun.nio.fs",

--- a/project-loader/CHANGELOG.md
+++ b/project-loader/CHANGELOG.md
@@ -7,6 +7,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Changes in versions before 2.0.0 are documented in the [root changelog](../CHANGELOG.md).
 
+## 5.0.0
+
+### Added
+
+- `ProjectLoader#executeWithProjects` to execute an action for multiple projects, applying the indexing workaround
+   to each, according to arguments.
+
+### Changed
+
+- `Args#forceIndexing` moved up to `EnvironmentArgs`.
+
 ## 4.0.0
 
 ### Added

--- a/project-loader/api/project-loader.api
+++ b/project-loader/api/project-loader.api
@@ -20,7 +20,6 @@ public final class de/itemis/mps/gradle/logging/LoggingFactoryKt {
 public class de/itemis/mps/gradle/project/loader/Args : de/itemis/mps/gradle/project/loader/EnvironmentArgs {
 	public fun <init> (Lcom/xenomachina/argparser/ArgParser;)V
 	public fun configureProjectLoader (Lde/itemis/mps/gradle/project/loader/ProjectLoader$Builder;)V
-	public final fun getForceIndexing ()Ljava/lang/Boolean;
 	public final fun getProject ()Ljava/io/File;
 }
 
@@ -34,6 +33,7 @@ public class de/itemis/mps/gradle/project/loader/EnvironmentArgs {
 	public fun configureProjectLoader (Lde/itemis/mps/gradle/project/loader/ProjectLoader$Builder;)V
 	public final fun getBuildNumber ()Ljava/lang/String;
 	public final fun getEnvironmentKind ()Lde/itemis/mps/gradle/project/loader/EnvironmentKind;
+	public final fun getForceIndexing ()Ljava/lang/Boolean;
 	public final fun getLogLevel ()Lde/itemis/mps/gradle/logging/LogLevel;
 	public final fun getMacros ()Ljava/util/List;
 	public final fun getPluginLocation ()Ljava/io/File;
@@ -120,6 +120,7 @@ public final class de/itemis/mps/gradle/project/loader/ProjectLoader {
 	public static final field Companion Lde/itemis/mps/gradle/project/loader/ProjectLoader$Companion;
 	public synthetic fun <init> (Ljetbrains/mps/tool/environment/EnvironmentConfig;Lde/itemis/mps/gradle/project/loader/EnvironmentKind;Ljava/io/File;Ljava/lang/String;Lde/itemis/mps/gradle/logging/LogLevel;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun execute (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun executeForEachProject (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public final fun executeWithProject (Ljava/io/File;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/Args.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/Args.kt
@@ -56,6 +56,17 @@ public open class EnvironmentArgs(parser: ArgParser) {
     public val skipLibraries: Boolean by parser.flagging("--no-libraries",
         help = "do not load project libraries under MPS environment")
 
+    public val forceIndexing: Boolean? by parser.storing(
+        "--force-indexing", help = "whether to force full indexing at startup to work around MPS-37926." +
+                " Supported values: always, never, auto. Default: auto.") {
+        when (this) {
+            "always" -> true
+            "never" -> false
+            "auto" -> null
+            else -> throw InvalidArgumentException("Unsupported value '$this'. Supported values are always, never, auto")
+        }
+    }.default(null)
+
     public open fun configureProjectLoader(builder: ProjectLoader.Builder) {
         builder.environmentConfig {
             plugins.addAll(this@EnvironmentArgs.plugins)
@@ -69,6 +80,8 @@ public open class EnvironmentArgs(parser: ArgParser) {
         builder.environmentKind = environmentKind
         builder.buildNumber = buildNumber
         builder.logLevel = de.itemis.mps.gradle.logging.LogLevel.valueOf(logLevel.toString())
+
+        builder.forceIndexing = forceIndexing
     }
 
     public fun buildLoader(): ProjectLoader = ProjectLoader.build(this::configureProjectLoader)
@@ -84,21 +97,8 @@ public open class Args(parser: ArgParser) : EnvironmentArgs(parser) {
     public val project: File by parser.storing("--project",
             help = "project to generate from") { File(this) }
 
-    public val forceIndexing: Boolean? by parser.storing(
-        "--force-indexing", help = "whether to force full indexing at startup to work around MPS-37926." +
-                " Supported values: always, never, auto. Default: auto.") {
-        when (this) {
-            "always" -> true
-            "never" -> false
-            "auto" -> null
-            else -> throw InvalidArgumentException("Unsupported value '$this'. Supported values are always, never, auto")
-        }
-    }.default(null)
-
     override fun configureProjectLoader(builder: ProjectLoader.Builder) {
         super.configureProjectLoader(builder)
-
-        builder.forceIndexing = forceIndexing
 
         if (!skipLibraries && environmentKind == EnvironmentKind.MPS) {
             builder.environmentConfig {

--- a/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLoader.kt
+++ b/project-loader/src/main/kotlin/de/itemis/mps/gradle/project/loader/ProjectLoader.kt
@@ -159,13 +159,31 @@ public class ProjectLoader private constructor(
 
     /**
      * Execute [action] in the context of an initialized MPS/IDEA environment and project located in [projectDir].
-     * Closes the project and shuts down the environment after the action finishes, even if it throws an exception.
+     * Closes the project after the action even if it throws an exception. Shuts down the environment after actions
+     * finish, even if it throws an exception.
+     *
+     * If an action for a project throws an exception, actions for further projects in the list are not performed.
      *
      * @param projectDir the directory to open as a MPS project
      * @param action action to execute.
      */
     public fun <T> executeWithProject(projectDir: File, action: (Environment, Project) -> T): T =
         execute { env -> withOpenProject(env, projectDir, action) }
+
+    /**
+     * Execute [action] in the manner of [executeWithProject] for each project in [projectDirs]. The environment is
+     * opened once, projects are opened sequentially, each project being closed before opening the next one.
+     *
+     * If [action] throws an exception for one of the projects, further projects in the list will not be processed.
+     * Closes the project and shuts down the environment after the action finishes, even if it throws an exception.
+     *
+     * @param projectDirs the directories to open as MPS projects
+     * @param action action to execute.
+     */
+    public fun <T> executeForEachProject(projectDirs: List<File>, action: (Environment, Project) -> T): List<T> =
+        execute { env ->
+            projectDirs.map { withOpenProject(env, it, action) }
+        }
 
     /**
      * Opens the project in [projectDir], executes [action] and disposes of the project regardless of whether [action]

--- a/remigrate/CHANGELOG.md
+++ b/remigrate/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) after reaching version 1.0.0. Until then any version may
 contain breaking changes.
 
+# 1.0.0
+
+## Added
+
+- The backend will now wait until project indices are built for each project before running migrations.
+
 # 0.3.0
 
 ## Added

--- a/remigrate/gradle.properties
+++ b/remigrate/gradle.properties
@@ -1,1 +1,1 @@
-version.backend=0.3.0
+version.backend=1.0.0

--- a/remigrate/src/main/kotlin/de/itemis/mps/gradle/remigrate/WorkFromIdeaPlugin.kt
+++ b/remigrate/src/main/kotlin/de/itemis/mps/gradle/remigrate/WorkFromIdeaPlugin.kt
@@ -85,7 +85,7 @@ private fun runProjectMigrations(project: Project, migrationsToExclude: Set<Stri
 }
 
 // A helper function to avoid deprecation warnings everywhere we need the project name
-@Suppress("DEPRECATION", "removal")
+@Suppress("DEPRECATION")
 private fun getName(project: Project) = project.name
 
 private fun resolve(languageRegistry: LanguageRegistry, reference: MigrationScriptReference): MigrationScript? =

--- a/remigrate/src/main/kotlin/de/itemis/mps/gradle/remigrate/remigrate.kt
+++ b/remigrate/src/main/kotlin/de/itemis/mps/gradle/remigrate/remigrate.kt
@@ -11,35 +11,21 @@ val logger = logging.getLogger("de.itemis.mps.gradle.migrate")
 
 fun remigrate(args: RemigrateArgs) {
     val loader = args.buildLoader()
+    val projectDirs = args.projects.map(::File)
     val moduleMigrationsToExclude = args.excludeModuleMigrations.toSet()
     val projectMigrationsToExclude = args.excludeProjectMigrations.toSet()
 
-    loader.execute { environment ->
+    loader.executeForEachProject(projectDirs) { environment, project ->
         val pluginId = PluginId.getId(PLUGIN_ID)
-        val pluginDescriptor = PluginManager.getInstance()
-            .findEnabledPlugin(pluginId)
+        val pluginDescriptor = PluginManager.getInstance().findEnabledPlugin(pluginId)
+            ?: throw Exception("Plugin $pluginId not loaded or not enabled, cannot proceed")
 
-        if (pluginDescriptor == null) {
-            throw Exception("Plugin $pluginId not loaded or not enabled, cannot proceed")
-        }
+        val helperClass = pluginDescriptor.pluginClassLoader!!.loadClass(WorkFromIdeaPlugin.javaClass.name)
+        val method = helperClass.getMethod("work", Project::class.java, Set::class.java, Set::class.java)
 
-        for (projectDir in args.projects) {
-            val project = environment.openProject(File(projectDir))
-            try {
-                val helperClass =
-                    pluginDescriptor.pluginClassLoader!!.loadClass(WorkFromIdeaPlugin.javaClass.name)
+        method.invoke(null, project, projectMigrationsToExclude, moduleMigrationsToExclude)
 
-                val method = helperClass.getMethod("work",
-                    Project::class.java,
-                    Set::class.java,
-                    Set::class.java)
-
-                method.invoke(null, project, projectMigrationsToExclude, moduleMigrationsToExclude)
-            } finally {
-                environment.closeProject(project)
-            }
-            environment.flushAllEvents()
-        }
+        environment.flushAllEvents()
     }
 }
 

--- a/test-projects/execute-method/.mps/migration.xml
+++ b/test-projects/execute-method/.mps/migration.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="MigrationProperties">
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.ExplicitJavaFacetSettings" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.SplitMPSCoreStub2" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.DataFlowStubsToRegularNodes" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.JavaModuleSettingsToFacet" value="executed" />
-    <entry key="project.baseline.version" value="211" />
     <entry key="project.migrated.version" value="232" />
   </component>
 </project>

--- a/test-projects/execute-method/.mps/vcs.xml
+++ b/test-projects/execute-method/.mps/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/test-projects/execute-method/solutions/my.solution/models/my.solution.java.mps
+++ b/test-projects/execute-method/solutions/my.solution/models/my.solution.java.mps
@@ -51,7 +51,7 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -61,13 +61,13 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/execute-method/solutions/my.solution/my.solution.msd
+++ b/test-projects/execute-method/solutions/my.solution/my.solution.msd
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.solution" uuid="468a495b-8ea4-49d8-b365-3c92887c30e0" moduleVersion="0" compileInMPS="true">
+<solution name="my.solution" uuid="468a495b-8ea4-49d8-b365-3c92887c30e0" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
@@ -18,7 +17,7 @@
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />

--- a/test-projects/generate-build-solution/.mps/migration.xml
+++ b/test-projects/generate-build-solution/.mps/migration.xml
@@ -5,5 +5,12 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.ExplicitJavaFacetSettings" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.SplitMPSCoreStub2" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.DataFlowStubsToRegularNodes" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.JavaModuleSettingsToFacet" value="executed" />
+    <entry key="project.migrated.version" value="232" />
   </component>
 </project>

--- a/test-projects/generate-build-solution/.mps/vcs.xml
+++ b/test-projects/generate-build-solution/.mps/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/test-projects/generate-build-solution/solutions/my.build/models/script.mps
+++ b/test-projects/generate-build-solution/solutions/my.build/models/script.mps
@@ -40,12 +40,12 @@
         <child id="5617550519002745378" name="macros" index="1l3spd" />
         <child id="5617550519002745372" name="layout" index="1l3spN" />
       </concept>
-      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
+      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ngI" index="1y1bJS">
         <child id="7389400916848037006" name="children" index="39821P" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/generate-build-solution/solutions/my.build/my.build.msd
+++ b/test-projects/generate-build-solution/solutions/my.build/my.build.msd
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.build" uuid="a4deeaa8-8bf4-485e-b06c-d772b56fee6a" moduleVersion="0" compileInMPS="true">
+<solution name="my.build" uuid="a4deeaa8-8bf4-485e-b06c-d772b56fee6a" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
   </dependencies>

--- a/test-projects/generate-build-solution/solutions/my.solution/models/java.mps
+++ b/test-projects/generate-build-solution/solutions/my.solution/models/java.mps
@@ -51,7 +51,7 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -61,13 +61,13 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/generate-build-solution/solutions/my.solution/my.solution.msd
+++ b/test-projects/generate-build-solution/solutions/my.solution/my.solution.msd
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.solution" uuid="b1f17f16-1c8d-4491-a51a-0a9b3adf1bef" moduleVersion="0" compileInMPS="true">
+<solution name="my.solution" uuid="b1f17f16-1c8d-4491-a51a-0a9b3adf1bef" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>

--- a/test-projects/generate-simple/.mps/migration.xml
+++ b/test-projects/generate-simple/.mps/migration.xml
@@ -5,5 +5,12 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.ExplicitJavaFacetSettings" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.SplitMPSCoreStub2" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.DataFlowStubsToRegularNodes" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.JavaModuleSettingsToFacet" value="executed" />
+    <entry key="project.migrated.version" value="232" />
   </component>
 </project>

--- a/test-projects/generate-simple/.mps/vcs.xml
+++ b/test-projects/generate-simple/.mps/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/test-projects/generate-simple/solutions/my.solution/models/java.mps
+++ b/test-projects/generate-simple/solutions/my.solution/models/java.mps
@@ -51,7 +51,7 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -61,13 +61,13 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/generate-simple/solutions/my.solution/my.solution.msd
+++ b/test-projects/generate-simple/solutions/my.solution/my.solution.msd
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.solution" uuid="d9927421-6b24-48e2-8240-37f994e23c40" moduleVersion="0" compileInMPS="true">
+<solution name="my.solution" uuid="d9927421-6b24-48e2-8240-37f994e23c40" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>

--- a/test-projects/generate-with-errors/.mps/vcs.xml
+++ b/test-projects/generate-with-errors/.mps/vcs.xml
@@ -8,6 +8,6 @@
     </profile>
   </component>
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/test-projects/generate-with-errors/solutions/correct/correct.msd
+++ b/test-projects/generate-with-errors/solutions/correct/correct.msd
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="correct" uuid="5685ccf5-0699-449d-a1cb-c79516b0b7b0" moduleVersion="0" compileInMPS="true">
+<solution name="correct" uuid="5685ccf5-0699-449d-a1cb-c79516b0b7b0" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>

--- a/test-projects/generate-with-errors/solutions/correct/models/correct.model.mps
+++ b/test-projects/generate-with-errors/solutions/correct/models/correct.model.mps
@@ -2,7 +2,7 @@
 <model ref="r:9fbc40ae-e182-4493-9a71-6327b0fea7df(correct.model)">
   <persistence version="9" />
   <languages>
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -46,20 +46,20 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/generate-with-errors/solutions/solution.with.errors/models/solution.with.errors.correct.mps
+++ b/test-projects/generate-with-errors/solutions/solution.with.errors/models/solution.with.errors.correct.mps
@@ -2,7 +2,7 @@
 <model ref="r:da7e88d4-abf1-4014-a7b1-3f6806496e77(solution.with.errors.correct)">
   <persistence version="9" />
   <languages>
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -46,20 +46,20 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/generate-with-errors/solutions/solution.with.errors/models/solution.with.errors.incorrect.mps
+++ b/test-projects/generate-with-errors/solutions/solution.with.errors/models/solution.with.errors.incorrect.mps
@@ -2,7 +2,7 @@
 <model ref="r:b6ab607b-aa99-46cd-9b4e-3f932086b82c(solution.with.errors.incorrect)">
   <persistence version="9" />
   <languages>
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports />
   <registry>
@@ -40,13 +40,13 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/generate-with-errors/solutions/solution.with.errors/solution.with.errors.msd
+++ b/test-projects/generate-with-errors/solutions/solution.with.errors/solution.with.errors.msd
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="solution.with.errors" uuid="7152e372-47ac-45cb-a010-4cbc0dbc7710" moduleVersion="0" compileInMPS="true">
+<solution name="solution.with.errors" uuid="7152e372-47ac-45cb-a010-4cbc0dbc7710" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>

--- a/test-projects/modelcheck/.mps/migration.xml
+++ b/test-projects/modelcheck/.mps/migration.xml
@@ -5,5 +5,12 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.ExplicitJavaFacetSettings" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2022_3.SplitMPSCoreStub2" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.DataFlowStubsToRegularNodes" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2023_1.JavaModuleSettingsToFacet" value="executed" />
+    <entry key="project.migrated.version" value="232" />
   </component>
 </project>

--- a/test-projects/modelcheck/.mps/vcs.xml
+++ b/test-projects/modelcheck/.mps/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/test-projects/modelcheck/solutions/my.solution.with.errors/models/java.mps
+++ b/test-projects/modelcheck/solutions/my.solution.with.errors/models/java.mps
@@ -2,7 +2,7 @@
 <model ref="r:098fce55-4c9a-4d06-84b9-04b5ca0d51c6(my.solution.with.errors.java)">
   <persistence version="9" />
   <languages>
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="ggvx" ref="r:a73d36b1-a672-4ac9-b2ff-9846b544fa43(my.solution.java)" />
@@ -14,13 +14,13 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/modelcheck/solutions/my.solution.with.errors/models/my.solution.with.errors.brokenref.mps
+++ b/test-projects/modelcheck/solutions/my.solution.with.errors/models/my.solution.with.errors.brokenref.mps
@@ -2,7 +2,7 @@
 <model ref="r:5cad4eaa-5797-4f86-a3ae-da123decf97d(my.solution.with.errors.brokenref)">
   <persistence version="9" />
   <languages>
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports />
   <registry>
@@ -22,14 +22,14 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/modelcheck/solutions/my.solution.with.errors/my.solution.with.errors.msd
+++ b/test-projects/modelcheck/solutions/my.solution.with.errors/my.solution.with.errors.msd
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.solution.with.errors" uuid="ff522c42-51e1-407c-8c1e-7646398c3def" moduleVersion="0" compileInMPS="true">
+<solution name="my.solution.with.errors" uuid="ff522c42-51e1-407c-8c1e-7646398c3def" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" languageLevel="JAVA_8">
+    <facet type="java" languageLevel="JAVA_8" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>

--- a/test-projects/modelcheck/solutions/my.solution.with.module.errors/my.solution.with.module.errors.msd
+++ b/test-projects/modelcheck/solutions/my.solution.with.module.errors/my.solution.with.module.errors.msd
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.solution.with.module.errors" uuid="002f5c40-2348-4a91-b6cd-3c9a74048c9f" moduleVersion="0" compileInMPS="true">
+<solution name="my.solution.with.module.errors" uuid="002f5c40-2348-4a91-b6cd-3c9a74048c9f" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">86530839-2a21-40f5-8fea-f98ec8d7d852(my.solution.non.existing)</dependency>
   </dependencies>

--- a/test-projects/modelcheck/solutions/my.solution/models/java.mps
+++ b/test-projects/modelcheck/solutions/my.solution/models/java.mps
@@ -51,7 +51,7 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -61,13 +61,13 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/test-projects/modelcheck/solutions/my.solution/my.solution.msd
+++ b/test-projects/modelcheck/solutions/my.solution/my.solution.msd
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="my.solution" uuid="c78f0546-c8a5-4368-9823-ad960fa28a88" moduleVersion="0" compileInMPS="true">
+<solution name="my.solution" uuid="c78f0546-c8a5-4368-9823-ad960fa28a88" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" languageLevel="JAVA_8">
+    <facet type="java" languageLevel="JAVA_8" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
-  <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>


### PR DESCRIPTION
See individual commits. The main changes are to wait until indices are built in remigrate and an additional `--add-open` JVM argument.