### PR TITLE
launcher: configure either generic or platform-specific jna library path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ version.project-loader=5.0.1
 
 # A comma-separated list of MPS releases or prereleases to test against.
 # Also used in the GitHub workflow to test each version in parallel
-supportedMpsVersions=2023.2.2,2024.1.2,2025.1.1,253.28294.219
+supportedMpsVersions=2023.2.2,2024.1.2,2025.1.1,253.28294.10805

--- a/launcher/CHANGELOG.md
+++ b/launcher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.8.1
+
+### Fixed
+
+- `jna.boot.library.path` is now configured using appropriate path either for generic or platform-specific distribution
+
 ## 2.8.0
 
 ### Added

--- a/launcher/gradle.properties
+++ b/launcher/gradle.properties
@@ -1,1 +1,1 @@
-version.launcher=2.8.0
+version.launcher=2.8.1

--- a/launcher/src/main/java/de/itemis/mps/gradle/launcher/MpsBackendBuilder.java
+++ b/launcher/src/main/java/de/itemis/mps/gradle/launcher/MpsBackendBuilder.java
@@ -171,7 +171,12 @@ public class MpsBackendBuilder {
                     result.add("-Dintellij.platform.load.app.info.from.resources=true");
                 }
                 if (mpsVersionValue.compareTo("2022.3") >= 0) {
-                    result.add("-Djna.boot.library.path=" + mpsHome.get().file("lib/jna/" + System.getProperty("os.arch")).getAsFile());
+                    Directory jnaLibBaseDir = mpsHome.get().dir("lib/jna");
+                    Directory jnaLibPlatformSpecificDir = jnaLibBaseDir.dir(System.getProperty("os.arch"));
+                    // use base JNA library directory only if it exists, but there is no platform-specific subdirectory
+                    // (-> platform-specific MPS distribution with copied JNA library, otherwise it's a generic MPS distribution with platform-specific directories)
+                    Directory jnaLibPath = (jnaLibBaseDir.getAsFile().exists() && !jnaLibPlatformSpecificDir.getAsFile().exists()) ? jnaLibBaseDir : jnaLibPlatformSpecificDir;
+                    result.add("-Djna.boot.library.path=" + jnaLibPath.getAsFile());
                 }
 
                 return result;


### PR DESCRIPTION
Current launcher implementation configures `jna.boot.library.path` always using a platform-specific path which is only available in the generic distribution (that contains multiple platform-specific native jna libs). Platform-specific distributions use instead by default a generic path that contains a platform-specific implementation for the target platform. This causes an issue when launching platform-specific distribution (mostly custom built RCPs) due to a missing JNA library.

This PR fixes the problem by picking up the platform-specific path for the generic distribution if the path exists or the generic path for platform-specific distributions. 

Additionally, this PR updates the latest supported version for MPS prereleases.

 